### PR TITLE
Allow Empty Seats/Zones for Players

### DIFF
--- a/gloomhaven/characters.ttslua
+++ b/gloomhaven/characters.ttslua
@@ -4,7 +4,9 @@ function characters.read_all(content)
   print("Reading characters")
 
   for i, character in pairs(content) do
-    characters.add_player(i, character)
+    if next(character) != nil then
+        characters.add_player(i, character)
+    end
   end
 end
 


### PR DESCRIPTION
Added in the ability to "skip" a zone when choosing where a player sits.   Simply add in an empty table into the the "characters" collection.

i.e.
 "characters": [
      **{},**
      {
        "class": "Plagueherald",
        "name": "Skippy",
..... Continue