### PR TITLE
Added getter for Sanctuary

### DIFF
--- a/gloomhaven/sanctuary.ttslua
+++ b/gloomhaven/sanctuary.ttslua
@@ -13,3 +13,12 @@ function sanctuary.read_sanctuary(sanctuaryContent)
     sanctuary_sticker.call("clickedPros", i)
   end
 end
+
+function sanctuary.get_value()
+  local sanctuary = getObjectFromGUID(guids.SANCTUARY_STICKER).getTable("Pros")
+  local total = 0
+  for i,j in pairs(sanctuary) do
+    if j then total = total + 1 end
+  end
+  return total
+end


### PR DESCRIPTION
- Adding getter for Sanctuary.ttslua for when SaveFile Writing becomes a thing
- I hate the usage of local variable "sanctuary" when it overlaps with the global table "sanctuary".  I did it like this to match with prosperity.ttslua.  In the other functions (from previous commit) I had to use sanctuaryContent so I could call a function without overlapping variable.
- Consider redoing how both this and Prosperity calculates this.  Consider instead just grabbing the "largest" value.  This would ensure if a checkbox was accidentally clicked in the middle, it wouldn't just "subtract one" from when the save/load occurred.