### PR TITLE
Repairing Sanctuary File Changes

### DIFF
--- a/gloomhaven/sanctuary.ttslua
+++ b/gloomhaven/sanctuary.ttslua
@@ -2,8 +2,8 @@ sanctuary = {}
 
 function sanctuary.load(value)
   local map = getObjectFromGUID(guids.MAP)
-  script.call('unseal')
-  utils.wait_for_object(guids.SANCTUARY_STICKER, function() sanctuary.read_sanctuary(sanctuaryContent) end)
+  map.call('unseal')
+  utils.wait_for_object(guids.SANCTUARY_STICKER, function() sanctuary.read_sanctuary(value) end)
 end
 
 
@@ -20,9 +20,9 @@ function sanctuary.save()
 end
 
 
-function sanctuary.read_sanctuary(sanctuaryContent)
+function sanctuary.read_sanctuary(value)
   local sanctuary_sticker = getObjectFromGUID(guids.SANCTUARY_STICKER)
-  for i = 0, sanctuaryContent-1 do
+  for i = 0, value-1 do
     sanctuary_sticker.call("clickedPros", i)
   end
 end

--- a/gloomhaven/save_handler.ttslua
+++ b/gloomhaven/save_handler.ttslua
@@ -68,7 +68,7 @@ function saveHandler.read_global(content)
     prosperity.load(content.prosperity)
   end
   if content.sanctuary then
-    sanctuary.read_all(content.sanctuary)
+    sanctuary.load(content.sanctuary)
   end
 end
 


### PR DESCRIPTION
fixed #8 

- Updated save_handler to call sanctuary.load instead of sanctuary.read_all (which was removed)
- updated variable reference from map to script in sanctuary.load
- renamed context variable to "value" to pass thru functions.