### PR TITLE
Fix Draw of Last Modifier Card

### DIFF
--- a/gloomhaven/characters.ttslua
+++ b/gloomhaven/characters.ttslua
@@ -148,6 +148,12 @@ function characters.setup_perks(player_zone, character)
   for _, perk in pairs(character.perks) do
     character_sheet.call('clickedToggle', "perk"..tostring(perk))
     characters.modify_deck(modifier_deck, additional_deck, perk_info[perk])
+    if additional_deck.remainder then
+      -- Remainder may only live for a single frame after last card is taken
+      -- May need to move this into the modify_deck routine itself to reduce
+      -- any delay.
+      additional_deck = additional_deck.remainder
+    end
   end
 
   modifier_deck.shuffle()
@@ -177,6 +183,10 @@ function characters.modify_deck(modifier_deck, additional_deck, info)
   if info.add then
     for _, card in pairs(info.add) do
       print("Adding: " .. card)
+      if additional_deck.name == "Card" then
+        additional_deck.putObject(modifier_deck)
+        return
+      end
       local found_card = characters.find_modifier_card(additional_deck, card)
       additional_deck.takeObject({
         guid = found_card.guid,


### PR DESCRIPTION
fixes #10 

- Using remainder property to determine if we have the last card.  
- Per Eldin on discord:  
> whenever you take the last to one card. deck.remainder will be set as a reference to the last card. Will only live for that frame though, because deck will be nil  next frame
https://discordapp.com/channels/342471570955960324/368208369812504587/714964663724408893

- It may be necessary to check&return remainder from the characters.modify_deck to have it closer to the takeObject.  Could also consider moving the loop inside characters.modify_deck to have complete control.
