### PR TITLE
Move Ability cards directly to Second Hand Position instead of using …

### DIFF
--- a/gloomhaven/character.ttslua
+++ b/gloomhaven/character.ttslua
@@ -93,12 +93,12 @@ function Character.loadAbilities(playerZone, character)
   if not character.abilities then return end
 
   local abilityDeck = Component.abilityDeck(playerZone)
+  local secondHandPos = {abilityDeck.getPosition().x,3,-59}
   for _, ability in pairs(character.abilities) do
     local abilityCard = Utils.findObjectInfoInStack(abilityDeck, {name=ability})
     abilityDeck.takeObject({
-      position = positions.getSafe(),
-      guid = abilityCard.guid,
-      callback_function = function(card) Character.moveToHand(card, playerZone, 2) end
+      position = secondHandPos,
+      guid = abilityCard.guid
     })
   end
 end


### PR DESCRIPTION
…Character.moveToHand

This moves the cards directly to where the "second hand" is, instead of moving somewhere else and then "drawing" via callback to Character.moveToHand.  This is much faster and also should fix #17 