### PR TITLE
Armor negative effects

### DIFF
--- a/gloomhaven/character.ttslua
+++ b/gloomhaven/character.ttslua
@@ -179,6 +179,8 @@ function Character.loadItems(playerZone, character)
   local characterSheet = Component.characterSheet(playerZone)
   local playerMat = Component.playerMat(playerZone)
 
+  local ignoreNegItemEffects = Character.hasNegItemEffectsPerk(character)
+
   local itemsText = ""
   for _, item in pairs(character.items) do
     local itemPosition
@@ -187,12 +189,35 @@ function Character.loadItems(playerZone, character)
     else
       itemPosition = positions.relativeToZone(playerZone, positions.ITEM_UNEQUIPPED)
     end
+
     Shop.getItem(item.name, itemPosition)
     itemsText = itemsText .. "\n" .. item.name
+
+    -- Perform check for adding of Negative Item Effects (-1 cards)
+    if not ignoreNegItemEffects then
+      local negativeEffect = Game.NegativeItemEffects[item.name]
+      if negativeEffect then
+        for i = 1, negativeEffect do
+          Character.dealNegativeItemEffectCard(itemPosition)
+        end
+      end
+    end
+
   end
   characterSheet.UI.setAttribute("Items", "text", itemsText)
 end
 
+function Character.hasNegItemEffectsPerk(character)
+  return false
+end
+
+function Character.dealNegativeItemEffectCard(itemPosition)
+  local deck = getObjectFromGUID(guids.PLAYER_MINUS_ONE_DECK)
+  deck.takeObject({
+    smooth = false,
+    position=itemPosition
+  })
+end
 
 function Character.moveToHand(object, playerZone, hand)
   local playerName = Game.PLAYERS[playerZone]

--- a/gloomhaven/character.ttslua
+++ b/gloomhaven/character.ttslua
@@ -208,6 +208,12 @@ function Character.loadItems(playerZone, character)
 end
 
 function Character.hasNegItemEffectsPerk(character)
+  local perkInfo = Game.CLASSES[character.class].perks
+  for _, perk in pairs(character.perks) do
+    if(perkInfo[perk].ignore == "I") then
+      return true
+    end
+  end
   return false
 end
 
@@ -215,7 +221,8 @@ function Character.dealNegativeItemEffectCard(itemPosition)
   local deck = getObjectFromGUID(guids.PLAYER_MINUS_ONE_DECK)
   deck.takeObject({
     smooth = false,
-    position=itemPosition
+    -- position set to ensure PLayer -1 cards placed on top.
+    position={itemPosition.x, itemPosition.y+1, itemPosition.z}
   })
 end
 

--- a/gloomhaven/component.ttslua
+++ b/gloomhaven/component.ttslua
@@ -15,6 +15,7 @@ guids.ACHIEVEMENTS_BAG = "3ea749" -- Bag containing the Achievement board
 guids.ACHIEVEMENT_BOARD = "43d5b8"
 guids.SANCTUARY_STICKER = "800847"
 guids.DECK_MAT = "a75fcd"
+guids.PLAYER_MINUS_ONE_DECK = "74a2ed"
 guids.CITY_EVENTS_DECK_INITIAL = "759349"
 guids.CITY_EVENTS_DECK = "f13efd"
 guids.ROAD_EVENTS_DECK_INITIAL = "83de73"

--- a/gloomhaven/game.ttslua
+++ b/gloomhaven/game.ttslua
@@ -2115,3 +2115,15 @@ Game.QUESTS = {
     number = 527
   },
 }
+
+Game.NegativeItemEffects = {
+  ["Hide Armor"] = 2,
+  ["Heavy Greaves"] = 1,
+  ["Chain Mail"] = 3,
+  ["Heavy Basinet"] = 2,
+  ["Splintmail"] = 4,
+  ["Steel Sabatons"] = 2,
+  ["Platemail"] = 5,
+  ["Swordedge Armor"] = 4,
+  ["Chain Hood"] = 1
+}


### PR DESCRIPTION
Fixes #29 
- Player -1 cards dealt on top of item cards as forced reminder to add them to deck if the item is equipped.
- Cards played on top in case people decide to shuffle around their item cards and forget to check -1 cards
- Warning: game.ttslua may contain spoilers of high prosperity/reward item names.

Save File to test
https://gist.github.com/GloomhavenSaveLoader/23384db87e13fe2d3006752b81933972